### PR TITLE
Migrate to Python3

### DIFF
--- a/eblib.py
+++ b/eblib.py
@@ -259,9 +259,9 @@ def test():
     eb = EBTest(sys.argv[1])
     if argc == 2:
         for subbook in eb.subbook_list():
-            print "#%d. %s (%s)" % (subbook,
+            print ("#%d. %s (%s)" % (subbook,
                                     eb.subbook_title(subbook),
-                                    eb.subbook_directory(subbook))
+                                    eb.subbook_directory(subbook)))
     else:
         eb.set_subbook(int(sys.argv[2]))
         word = sys.argv[3]
@@ -274,9 +274,9 @@ def test():
         else:
             func = eb.search_exactword
         for hit in func(word):
-            print "-" * 40
-            print hit.heading()
-            print hit.text()
+            print ("-" * 40)
+            print (hit.heading())
+            print (hit.text())
     eb_finalize_library()
 
 if __name__ == "__main__":

--- a/examples/chujiten.py
+++ b/examples/chujiten.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  chujiten.py - an add-on program for xyaku
 #                Tamito KAJIYAMA <12 September 2001>

--- a/examples/test.py
+++ b/examples/test.py
@@ -19,17 +19,17 @@ import re
 def get_content(book, appendix, hookset, folded, packed):
     buffer = []
     while 1:
-        data = eb_read_text(book, appendix, hookset, None)
+        data = eb_read_text(book, appendix, hookset, None).decode('euc-jp', errors='ignore')
         if not data:
             break
-        data = string.replace(data, "→§", "")
-        data = string.replace(data, "＝→", "＝")
-        data = string.replace(data, "⇒→", "⇒")
-        data = string.replace(data, "⇔→", "⇔")
+        data = data.replace("→§", "")
+        data = data.replace("＝→", "＝")
+        data = data.replace("⇒→", "⇒")
+        data = data.replace("⇔→", "⇔")
         buffer.append(data)
-    data = string.join(buffer, "")
+    data = "".join(buffer)
     if packed:
-        data = string.replace(data, "\n", "") + "\n"
+        data = data.replace("\n", "") + "\n"
     if folded < 0:
         return data
     i = end = 0
@@ -156,12 +156,12 @@ def main():
         sys.exit(1)
     eb_set_subbook(book, 0)
     if len(args) == 0:
-        word = string.strip(sys.stdin.read())
+        word = sys.stdin.read().strip()
     else:
         word = string.join(args)
     for word in make_candidates(word):
         found = 0
-        eb_search_exactword(book, unicode(word,'utf-8').encode('euc-jp'))
+        eb_search_exactword(book, word.encode('euc-jp'))
         while 1:
             hitlist = eb_hit_list(book)
             if not hitlist:
@@ -169,10 +169,10 @@ def main():
             found = 1
             for heading, text in hitlist:
                 eb_seek_text(book, text)
-                content = get_content(book, appendix, hookset, folded, packed)
-                if string.strip(content):
+                content = get_content(book, appendix, hookset, folded, packed).strip()
+                if content:
                     #sys.stdout.write(unicode(content,'euc-jp',errors='ignore'))
-                    print(unicode(content,'euc-jp',errors='ignore'))
+                    print(content)
         if found:
             break
     eb_finalize_library()

--- a/examples/test.py
+++ b/examples/test.py
@@ -150,9 +150,9 @@ def main():
         (EB_HOOK_WIDE_FONT,   hook_font)))
     try:
         eb_bind(book, dictdir)
-    except EBError, (error, message):
-        code = eb_error_string(error)
-        sys.stderr.write("Error: %s: %s\n" % (code, message))
+    except EBError as exc:
+        code = eb_error_string(exc.args[0])
+        sys.stderr.write("Error: %s: %s\n" % (code, exc.args[1]))
         sys.exit(1)
     eb_set_subbook(book, 0)
     if len(args) == 0:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ else:
     INCLUDE_DIRS = ['/usr/local/include', './src']
     LIBRARY_DIRS = None
 
-setup (name = 'ebmodule',
+setup (name = 'eb',
        version = '2.3',
        description = 'A wrapper module of the EB library',
        author = 'Tamito KAJIYAMA',
@@ -29,7 +29,7 @@ setup (name = 'ebmodule',
        url = 'http://pseudo.grad.sccs.chukyo-u.ac.jp/~kajiyama/python/',
        py_modules = ['eblib'],
        ext_modules = [
-           Extension('ebmodule', [EBMODULE_C],
+           Extension('eb', [EBMODULE_C],
                      include_dirs=INCLUDE_DIRS,
                      library_dirs=LIBRARY_DIRS,
                      #library_dirs=['/home/plateau/src/ebmodule-2.0/src/eb/.libs','/home/plateau/src/ebmodule-2.0/src/eb_lib/zlib/.libs'],

--- a/src/ebmodule.c
+++ b/src/ebmodule.c
@@ -33,6 +33,34 @@ static char *version = ""
 static PyObject *EBError;
 static PyObject *CallbackContext;
 
+#if PY_MAJOR_VERSION >= 3
+    #define PyInt_FromLong PyLong_FromLong
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyInt_Check PyLong_Check
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyInt_AsLong PyLong_AsLong
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyString_FromString PyUnicode_FromString
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyString_AsString PyUnicode_AsUTF8
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+    #define PyString_Check PyUnicode_Check
+#endif
+
 #define error_object(status) \
         Py_BuildValue("(is)", status, eb_error_message(status))
 
@@ -77,7 +105,7 @@ static struct PyMethodDef Book_methods[] = {
   {NULL, NULL}  /* sentinel */
 };
 
-staticforward PyTypeObject BookType;
+static PyTypeObject BookType;
 
 static BookObject *
 book_new(void)
@@ -101,7 +129,7 @@ book_dealloc(BookObject *self)
 static PyObject *
 book_getattr(BookObject *self, char *name)
 {
-  return Py_FindMethod(Book_methods, (PyObject *)self, name);
+  return PyObject_GenericGetAttr((PyObject *) self, PyString_FromString(name));
 }
 
 /*static PyMemberDef Book_members[] = {*/
@@ -113,8 +141,7 @@ static char BookType__doc__[] =
 "A data structure for representing Book objects.";
 
 static PyTypeObject BookType = {
-  PyObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type))
-  0,				/*ob_size*/
+  PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
   "EB_Book",			/*tp_name*/
   sizeof(BookObject),		/*tp_basicsize*/
   0,				/*tp_itemsize*/
@@ -123,7 +150,6 @@ static PyTypeObject BookType = {
   (printfunc)0,			/*tp_print*/
   (getattrfunc)book_getattr,	/*tp_getattr*/
   (setattrfunc)0,		/*tp_setattr*/
-  (cmpfunc)0,			/*tp_compare*/
   (reprfunc)0,			/*tp_repr*/
   0,				/*tp_as_number*/
   0,				/*tp_as_sequence*/
@@ -154,7 +180,7 @@ static struct PyMethodDef Appendix_methods[] = {
   {NULL, NULL}  /* sentinel */
 };
 
-staticforward PyTypeObject AppendixType;
+static PyTypeObject AppendixType;
 
 static AppendixObject *
 appendix_new(void)
@@ -178,15 +204,14 @@ appendix_dealloc(AppendixObject *self)
 static PyObject *
 appendix_getattr(AppendixObject *self, char *name)
 {
-  return Py_FindMethod(Appendix_methods, (PyObject *)self, name);
+  return PyObject_GenericGetAttr((PyObject *) self, PyString_FromString(name));
 }
 
 static char AppendixType__doc__[] =
 "A data structure for representing Appendix objects.";
 
 static PyTypeObject AppendixType = {
-  PyObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type))
-  0,				/*ob_size*/
+  PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
   "EB_Appendix",		/*tp_name*/
   sizeof(AppendixObject),	/*tp_basicsize*/
   0,				/*tp_itemsize*/
@@ -195,7 +220,6 @@ static PyTypeObject AppendixType = {
   (printfunc)0,			/*tp_print*/
   (getattrfunc)appendix_getattr,/*tp_getattr*/
   (setattrfunc)0,		/*tp_setattr*/
-  (cmpfunc)0,			/*tp_compare*/
   (reprfunc)0,			/*tp_repr*/
   0,				/*tp_as_number*/
   0,				/*tp_as_sequence*/
@@ -223,7 +247,7 @@ static struct PyMethodDef Hookset_methods[] = {
   {NULL, NULL}  /* sentinel */
 };
 
-staticforward PyTypeObject HooksetType;
+static PyTypeObject HooksetType;
 
 static HooksetObject *
 hookset_new(void)
@@ -249,15 +273,14 @@ hookset_dealloc(HooksetObject *self)
 static PyObject *
 hookset_getattr(HooksetObject *self, char *name)
 {
-  return Py_FindMethod(Hookset_methods, (PyObject *)self, name);
+  return PyObject_GenericGetAttr((PyObject *) self, PyString_FromString(name));
 }
 
 static char HooksetType__doc__[] =
 "A data type for representing Hookset objects.";
 
 static PyTypeObject HooksetType = {
-  PyObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type))
-  0,				/*ob_size*/
+  PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
   "EB_Hookset",			/*tp_name*/
   sizeof(HooksetObject),	/*tp_basicsize*/
   0,				/*tp_itemsize*/
@@ -266,7 +289,6 @@ static PyTypeObject HooksetType = {
   (printfunc)0,			/*tp_print*/
   (getattrfunc)hookset_getattr,	/*tp_getattr*/
   (setattrfunc)0,		/*tp_setattr*/
-  (cmpfunc)0,			/*tp_compare*/
   (reprfunc)0,			/*tp_repr*/
   0,				/*tp_as_number*/
   0,				/*tp_as_sequence*/
@@ -3084,14 +3106,33 @@ static struct PyMethodDef eb_module_methods[] = {
 
 static char eb_module_documentation[] = "";
 
+#if PY_MAJOR_VERSION >= 3
+PyMODINIT_FUNC
+PyInit_eb(void)
+#else
 void
 initeb(void)
+#endif
 {
   PyObject *m, *d;
 
+#if PY_MAJOR_VERSION >= 3
+  static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "eb",     /* m_name */
+    eb_module_documentation,  /* m_doc */
+    -1,                  /* m_size */
+    eb_module_methods    /* m_methods */
+  };
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+  m = PyModule_Create(&moduledef);
+#else
   /* Create the module and add the functions */
   m = Py_InitModule4("eb", eb_module_methods, eb_module_documentation,
 		     (PyObject*)NULL, PYTHON_API_VERSION);
+#endif
 
   /* Add some symbolic constants to the module */
   d = PyModule_GetDict(m);
@@ -3320,4 +3361,5 @@ initeb(void)
   /* Check for errors */
   if (PyErr_Occurred())
     Py_FatalError("can't initialize the eb module");
+  return m;
 }

--- a/src/ebmodule.c
+++ b/src/ebmodule.c
@@ -544,7 +544,7 @@ py_eb_search_exactword(PyObject *self, PyObject *args)
   const char *query;
   int status;
 
-  if (!PyArg_ParseTuple(args, "O!s", &BookType, &book, &query))
+  if (!PyArg_ParseTuple(args, "O!y", &BookType, &book, &query))
     return NULL;
   status = eb_search_exactword(&book->book, query);
   if (status != EB_SUCCESS) {
@@ -1722,7 +1722,7 @@ py_eb_read_text(PyObject *self, PyObject *args)
     PyErr_SetObject(EBError, error_object(status));
     return NULL;
   }
-  return PyString_FromStringAndSize(buffer, len);
+  return PyBytes_FromStringAndSize(buffer, len);
 }
 
 static char py_eb_read_heading__doc__[] = "eb_read_heading(book, appendix, hookset) => string Read a data chunk of the entry heading.  In order to read all the data chunks, applications have to call this function several times until it returns a null string.  Raise EBError if failed.";
@@ -1753,7 +1753,7 @@ py_eb_read_heading(PyObject *self, PyObject *args)
     PyErr_SetObject(EBError, error_object(status));
     return NULL;
   }
-  return PyString_FromStringAndSize(buffer, len);
+  return PyBytes_FromStringAndSize(buffer, len);
 }
 
 static char py_eb_read_rawtext__doc__[] = "eb_read_rawtext(book, int) => string Return the given number of raw characters read from the current file position.  Raise EBError if failed.";
@@ -1776,7 +1776,7 @@ py_eb_read_rawtext(PyObject *self, PyObject *args)
     PyErr_SetObject(EBError, error_object(status));
     return NULL;
   }
-  string = PyString_FromStringAndSize(buffer, len);
+  string = PyBytes_FromStringAndSize(buffer, len);
   free(buffer);
   return string;
 }


### PR DESCRIPTION
I had to upgrade this to support python3 for my project, so thought I'd create a pull request in case anyone else needs it.  It was a somewhat nontrivial change, due to the differences in default string encoding between python2 and python3.

I'm a python beginner and literally my first time using Python C Extensions, so there's likely some stuff I missed or at least something that could be better.
Maybe want to merge this into a separate branch so users can choose between python2 or 3?

Testing: the test.py works.